### PR TITLE
Add v1.3.0

### DIFF
--- a/repo/meta/index.json
+++ b/repo/meta/index.json
@@ -1,7 +1,7 @@
 {
   "packages":[
     {
-      "currentVersion":"1.2.0",
+      "currentVersion":"1.3.0",
       "description":"A distributed NoSQL key-value data store that offers high availability, fault tolerance, operational simplicity, and scalability.",
       "framework":true,
       "name":"riak",
@@ -14,7 +14,8 @@
       ],
       "versions":{
         "1.1.0":"0",
-        "1.2.0":"1"
+        "1.2.0":"1",
+        "1.3.0":"2"
       }
     }
   ],

--- a/repo/packages/R/riak/2/command.json
+++ b/repo/packages/R/riak/2/command.json
@@ -1,6 +1,6 @@
 {
   "pip": [
-    "git+https://github.com/basho-labs/riak-mesos-tools.git@1.3.1egg=riak_mesos",
+    "git+https://github.com/basho-labs/riak-mesos-tools.git@1.3.1#egg=riak_mesos",
     "git+https://github.com/basho-labs/riak-mesos-dcos-shims@master"
   ]
 }

--- a/repo/packages/R/riak/2/command.json
+++ b/repo/packages/R/riak/2/command.json
@@ -1,6 +1,6 @@
 {
   "pip": [
-    "git+https://github.com/basho-labs/riak-mesos-tools.git@1.3.0#egg=riak_mesos",
+    "git+https://github.com/basho-labs/riak-mesos-tools.git@mtc-fix-director-wait-for-service#egg=riak_mesos",
     "git+https://github.com/basho-labs/riak-mesos-dcos-shims@master"
   ]
 }

--- a/repo/packages/R/riak/2/command.json
+++ b/repo/packages/R/riak/2/command.json
@@ -1,6 +1,6 @@
 {
   "pip": [
-    "git+https://github.com/basho-labs/riak-mesos-tools.git@1.3.1#egg=riak_mesos",
+    "git+https://github.com/basho-labs/riak-mesos-tools.git@1.3.2#egg=riak_mesos",
     "git+https://github.com/basho-labs/riak-mesos-dcos-shims@master"
   ]
 }

--- a/repo/packages/R/riak/2/command.json
+++ b/repo/packages/R/riak/2/command.json
@@ -1,0 +1,6 @@
+{
+  "pip": [
+    "git+https://github.com/basho-labs/riak-mesos-tools.git@1.3.0#egg=riak_mesos",
+    "git+https://github.com/basho-labs/riak-mesos-dcos-shims@master"
+  ]
+}

--- a/repo/packages/R/riak/2/command.json
+++ b/repo/packages/R/riak/2/command.json
@@ -1,6 +1,6 @@
 {
   "pip": [
-    "git+https://github.com/basho-labs/riak-mesos-tools.git@mtc-fix-director-wait-for-service#egg=riak_mesos",
+    "git+https://github.com/basho-labs/riak-mesos-tools.git@1.3.1egg=riak_mesos",
     "git+https://github.com/basho-labs/riak-mesos-dcos-shims@master"
   ]
 }

--- a/repo/packages/R/riak/2/config.json
+++ b/repo/packages/R/riak/2/config.json
@@ -109,12 +109,12 @@
                         "url": {
                             "type": "string",
                             "description": "Package location for Riak Mesos Scheduler tarball.",
-                            "default": "https://github.com/basho-labs/riak-mesos-scheduler/releases/download/1.4.1/riak_mesos_scheduler-1.4.1-mesos-0.28.1-ubuntu-14.04.tar.gz"
+                            "default": "https://github.com/basho-labs/riak-mesos-scheduler/releases/download/1.8.0/riak_mesos_scheduler-1.8.0-mesos-1.0.0-ubuntu-14.04.tar.gz"
                         },
                         "package": {
                             "type": "string",
                             "description": "Package name for Riak Mesos Scheduler tarball.",
-                            "default": "riak_mesos_scheduler-1.4.1-mesos-0.28.1-ubuntu-14.04.tar.gz"
+                            "default": "riak_mesos_scheduler-1.8.0-mesos-1.0.0-ubuntu-14.04.tar.gz"
                         },
                         "cpus": {
                             "type": "number",
@@ -140,12 +140,12 @@
                         "url": {
                             "type": "string",
                             "description": "Package location for Riak Mesos Executor tarball.",
-                            "default": "https://github.com/basho-labs/riak-mesos-executor/releases/download/1.4.0/riak_mesos_executor-1.4.0-mesos-0.28.1-ubuntu-14.04.tar.gz"
+                            "default": "https://github.com/basho-labs/riak-mesos-executor/releases/download/1.7.0/riak_mesos_executor-1.7.0-mesos-1.0.0-ubuntu-14.04.tar.gz"
                         },
                         "package": {
                             "type": "string",
                             "description": "Package name for Riak Mesos Executor tarball.",
-                            "default": "riak_mesos_executor-1.4.0-mesos-0.28.1-ubuntu-14.04.tar.gz"
+                            "default": "riak_mesos_executor-1.7.0-mesos-1.0.0-ubuntu-14.04.tar.gz"
                         },
                         "cpus": {
                             "type": "number",
@@ -176,22 +176,22 @@
                         "patches-url": {
                             "type": "string",
                             "description": "Package location for Riak patches tarball.",
-                            "default": "https://github.com/basho-labs/riak-mesos-executor/releases/download/1.4.0/riak_erlpmd_patches-1.4.0-mesos-0.28.1-ubuntu-14.04.tar.gz"
+                            "default": "https://github.com/basho-labs/riak-mesos-executor/releases/download/1.7.0/riak_erlpmd_patches-1.7.0-mesos-1.0.0-ubuntu-14.04.tar.gz"
                         },
                         "patches-package": {
                             "type": "string",
                             "description": "Package name for Riak patches tarball.",
-                            "default": "riak_erlpmd_patches-1.4.0-mesos-0.28.1-ubuntu-14.04.tar.gz"
+                            "default": "riak_erlpmd_patches-1.7.0-mesos-1.0.0-ubuntu-14.04.tar.gz"
                         },
                         "explorer-url": {
                             "type": "string",
                             "description": "Package location for Riak Explorer tarball.",
-                            "default": "https://github.com/basho-labs/riak_explorer/releases/download/1.1.1/riak_explorer-1.1.1.patch-ubuntu-14.04.tar.gz"
+                            "default": "https://github.com/basho-labs/riak_explorer/releases/download/1.2.1/riak_explorer-1.2.1.patch-ubuntu-14.04.tar.gz"
                         },
                         "explorer-package": {
                             "type": "string",
                             "description": "Package name for Riak Explorer tarball.",
-                            "default": "riak_explorer-1.1.1.patch-ubuntu-14.04.tar.gz"
+                            "default": "riak_explorer-1.2.1.patch-ubuntu-14.04.tar.gz"
                         },
                         "cpus": {
                             "type": "number",

--- a/repo/packages/R/riak/2/config.json
+++ b/repo/packages/R/riak/2/config.json
@@ -109,12 +109,12 @@
                         "url": {
                             "type": "string",
                             "description": "Package location for Riak Mesos Scheduler tarball.",
-                            "default": "https://github.com/basho-labs/riak-mesos-scheduler/releases/download/1.8.0/riak_mesos_scheduler-1.8.0-mesos-1.0.0-ubuntu-14.04.tar.gz"
+                            "default": "https://github.com/basho-labs/riak-mesos-scheduler/releases/download/1.8.1/riak_mesos_scheduler-1.8.1-mesos-1.0.0-ubuntu-14.04.tar.gz"
                         },
                         "package": {
                             "type": "string",
                             "description": "Package name for Riak Mesos Scheduler tarball.",
-                            "default": "riak_mesos_scheduler-1.8.0-mesos-1.0.0-ubuntu-14.04.tar.gz"
+                            "default": "riak_mesos_scheduler-1.8.1-mesos-1.0.0-ubuntu-14.04.tar.gz"
                         },
                         "cpus": {
                             "type": "number",

--- a/repo/packages/R/riak/2/config.json
+++ b/repo/packages/R/riak/2/config.json
@@ -1,0 +1,261 @@
+{
+    "type": "object",
+    "properties": {
+        "riak": {
+            "type": "object",
+            "description": "Riak Mesos Framework specific properties",
+            "properties": {
+                "framework-name": {
+                    "type": "string",
+                    "description": "Framework Instance Name.",
+                    "default": "riak"
+                },
+                "hostname": {
+                    "default": "riak.marathon.mesos",
+                    "type": "string",
+                    "description": "Framework HTTP API hostname."
+                },
+                "marathon": {
+                    "type": "string",
+                    "description": "The Marathon URL.",
+                    "default": "marathon.mesos:8080"
+                },
+                "master": {
+                    "type": "string",
+                    "description": "The URL of the Mesos master.",
+                    "default": "leader.mesos:5050"
+                },
+                "zk": {
+                    "type": "string",
+                    "description": "Zookeeper address. Specify in the format host:port.",
+                    "default": "leader.mesos:2181"
+                },
+                "user": {
+                    "type": "string",
+                    "description": "Framework User.",
+                    "default": "root"
+                },
+                "role": {
+                    "type": "string",
+                    "description": "Framework Role.",
+                    "default": "riak"
+                },
+                "auth-principal": {
+                    "type": "string",
+                    "description": "Mesos authentication principal.",
+                    "default": ""
+                },
+                "auth-provider": {
+                    "type": "string",
+                    "description": "Mesos authentication provider.",
+                    "default": ""
+                },
+                "auth-secret-file": {
+                    "type": "string",
+                    "description": "Mesos authentication secret file.",
+                    "default": ""
+                },
+                "instances": {
+                    "type": "number",
+                    "description": "Number of framework instances",
+                    "default": 1
+                },
+                "healthcheck-grace-period-seconds": {
+                    "type": "number",
+                    "description": "Memory requirements",
+                    "default": 300
+                },
+                "healthcheck-interval-seconds": {
+                    "type": "number",
+                    "description": "Memory requirements",
+                    "default": 60
+                },
+                "healthcheck-timeout-seconds": {
+                    "type": "number",
+                    "description": "Memory requirements",
+                    "default": 20
+                },
+                "healthcheck-max-consecutive-failures": {
+                    "type": "number",
+                    "description": "Memory requirements",
+                    "default": 5
+                },
+                "constraints": {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "items": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "string",
+                                "enum": ["UNIQUE", "CLUSTER", "GROUP_BY", "LIKE", "UNLIKE"]
+                            },
+                            {
+                                "type": "string"
+                            }
+                        ],
+                        "minItems": 2,
+                        "additionalItems": false
+                    },
+                    "description": "Marathon constraints for the framework/scheduler instance. Valid constraint operators are one of UNIQUE, CLUSTER, GROUP_BY, LIKE, UNLIKE.",
+                    "default": []
+                },
+                "scheduler": {
+                    "type": "object",
+                    "description": "Requirements for Riak Mesos Scheduler",
+                    "properties": {
+                        "url": {
+                            "type": "string",
+                            "description": "Package location for Riak Mesos Scheduler tarball.",
+                            "default": "https://github.com/basho-labs/riak-mesos-scheduler/releases/download/1.4.1/riak_mesos_scheduler-1.4.1-mesos-0.28.1-ubuntu-14.04.tar.gz"
+                        },
+                        "package": {
+                            "type": "string",
+                            "description": "Package name for Riak Mesos Scheduler tarball.",
+                            "default": "riak_mesos_scheduler-1.4.1-mesos-0.28.1-ubuntu-14.04.tar.gz"
+                        },
+                        "cpus": {
+                            "type": "number",
+                            "description": "Riak Mesos Scheduler CPU requirements",
+                            "default": 0.5
+                        },
+                        "mem": {
+                            "type": "number",
+                            "description": "Riak Mesos Scheduler Memory requirements",
+                            "default": 2048.0
+                        },
+                        "constraints": {
+                            "type": "string",
+                            "default": "[]",
+                            "description": "Scheduler constraints for Riak node tasks. Valid constraint operators are one of UNIQUE, CLUSTER, GROUP_BY, LIKE, UNLIKE."
+                        }
+                    }
+                },
+                "executor": {
+                    "type": "object",
+                    "description": "Requirements for Riak Mesos Executor",
+                    "properties": {
+                        "url": {
+                            "type": "string",
+                            "description": "Package location for Riak Mesos Executor tarball.",
+                            "default": "https://github.com/basho-labs/riak-mesos-executor/releases/download/1.4.0/riak_mesos_executor-1.4.0-mesos-0.28.1-ubuntu-14.04.tar.gz"
+                        },
+                        "package": {
+                            "type": "string",
+                            "description": "Package name for Riak Mesos Executor tarball.",
+                            "default": "riak_mesos_executor-1.4.0-mesos-0.28.1-ubuntu-14.04.tar.gz"
+                        },
+                        "cpus": {
+                            "type": "number",
+                            "description": "Riak Mesos Executor CPU requirements",
+                            "default": 0.1
+                        },
+                        "mem": {
+                            "type": "number",
+                            "description": "Riak Mesos Executor Memory requirements",
+                            "default": 512.0
+                        }
+                    }
+                },
+                "node": {
+                    "type": "object",
+                    "description": "Requirements for Riak",
+                    "properties": {
+                        "url": {
+                            "type": "string",
+                            "description": "Package location for Riak tarball.",
+                            "default": "https://github.com/basho-labs/riak-mesos/releases/download/1.2.0/riak-2.1.4-ubuntu-14.04.tar.gz"
+                        },
+                        "package": {
+                            "type": "string",
+                            "description": "Package name for Riak tarball.",
+                            "default": "riak-2.1.4-ubuntu-14.04.tar.gz"
+                        },
+                        "patches-url": {
+                            "type": "string",
+                            "description": "Package location for Riak patches tarball.",
+                            "default": "https://github.com/basho-labs/riak-mesos-executor/releases/download/1.4.0/riak_erlpmd_patches-1.4.0-mesos-0.28.1-ubuntu-14.04.tar.gz"
+                        },
+                        "patches-package": {
+                            "type": "string",
+                            "description": "Package name for Riak patches tarball.",
+                            "default": "riak_erlpmd_patches-1.4.0-mesos-0.28.1-ubuntu-14.04.tar.gz"
+                        },
+                        "explorer-url": {
+                            "type": "string",
+                            "description": "Package location for Riak Explorer tarball.",
+                            "default": "https://github.com/basho-labs/riak_explorer/releases/download/1.1.1/riak_explorer-1.1.1.patch-ubuntu-14.04.tar.gz"
+                        },
+                        "explorer-package": {
+                            "type": "string",
+                            "description": "Package name for Riak Explorer tarball.",
+                            "default": "riak_explorer-1.1.1.patch-ubuntu-14.04.tar.gz"
+                        },
+                        "cpus": {
+                            "type": "number",
+                            "description": "Riak CPU requirements",
+                            "default": 1.0
+                        },
+                        "mem": {
+                            "type": "number",
+                            "description": "Riak Memory requirements",
+                            "default": 8000.0
+                        },
+                        "disk": {
+                            "type": "number",
+                            "description": "Riak Disk requirements",
+                            "default": 20000.0
+                        }
+                    }
+                },
+                "director": {
+                    "type": "object",
+                    "description": "Requirements for Riak Mesos Director",
+                    "properties": {
+                        "url": {
+                            "type": "string",
+                            "description": "Package location for Riak Mesos Director tarball.",
+                            "default": "https://github.com/basho-labs/riak-mesos-director/releases/download/1.0.1/riak_mesos_director-1.0.1-ubuntu-14.04.tar.gz"
+                        },
+                        "use-public": {
+                            "type": "boolean",
+                            "description": "When true, only deploys director on public agents.",
+                            "default": false
+                        },
+                        "cpus": {
+                            "type": "number",
+                            "description": "Riak Mesos Director CPU requirements",
+                            "default": 0.5
+                        },
+                        "mem": {
+                            "type": "number",
+                            "description": "Riak Director Memory requirements",
+                            "default": 1024.0
+                        }
+                    }
+                }
+            },
+            "required": [
+                "framework-name",
+                "hostname",
+                "marathon",
+                "master",
+                "zk",
+                "user",
+                "role",
+                "auth-principal",
+                "instances",
+                "healthcheck-grace-period-seconds",
+                "healthcheck-interval-seconds",
+                "healthcheck-timeout-seconds",
+                "healthcheck-max-consecutive-failures",
+                "scheduler",
+                "executor",
+                "node",
+                "director"
+            ]
+        }
+    }
+}

--- a/repo/packages/R/riak/2/marathon.json.mustache
+++ b/repo/packages/R/riak/2/marathon.json.mustache
@@ -1,0 +1,52 @@
+{
+    "id":"{{riak.framework-name}}",
+    "instances": {{riak.instances}},
+    "cpus": {{riak.scheduler.cpus}},
+    "mem": {{riak.scheduler.mem}},
+    "ports":[ 0 ],
+    "uris": ["{{riak.scheduler.url}}", "{{riak.executor.url}}", "{{riak.node.url}}", "{{riak.node.explorer-url}}", "{{riak.node.patches-url}}"],
+    "cmd":"./riak_mesos_scheduler/bin/ermf-scheduler",
+    {{#riak.constraints}}"constraints": {{{riak.constraints}}},{{/riak.constraints}}
+    "env": {
+        "RIAK_MESOS_NAME": "{{riak.framework-name}}"
+        ,"RIAK_MESOS_ZK": "{{riak.zk}}"
+        ,"RIAK_MESOS_MASTER": "{{riak.master}}"
+        ,"RIAK_MESOS_USER": "{{riak.user}}"
+        ,"RIAK_MESOS_DIRECTOR_URL": "{{riak.director.url}}"
+        ,"RIAK_MESOS_DIRECTOR_CPUS": "{{riak.director.cpus}}"
+        ,"RIAK_MESOS_DIRECTOR_MEM": "{{riak.director.mem}}"
+        {{#riak.director.use-public}},"RIAK_MESOS_DIRECTOR_PUBLIC": "{{riak.director.use-public}}"{{/riak.director.use-public}}
+        {{#riak.scheduler.package}},"RIAK_MESOS_SCHEDULER_PKG": "{{riak.scheduler.package}}"{{/riak.scheduler.package}}
+        {{#riak.executor.package}},"RIAK_MESOS_EXECUTOR_PKG": "{{riak.executor.package}}"{{/riak.executor.package}}
+        {{#riak.node.package}},"RIAK_MESOS_RIAK_PKG": "{{riak.node.package}}"{{/riak.node.package}}
+        {{#riak.node.patches-package}},"RIAK_MESOS_PATCHES_PKG": "{{riak.node.patches-package}}"{{/riak.node.patches-package}}
+        {{#riak.node.explorer-package}},"RIAK_MESOS_EXPLORER_PKG": "{{riak.node.explorer-package}}"{{/riak.node.explorer-package}}
+        {{#riak.scheduler.constraints}},"RIAK_MESOS_CONSTRAINTS": "{{riak.scheduler.constraints}}"{{/riak.scheduler.constraints}}
+        {{#riak.auth-principal}},"RIAK_MESOS_PRINCIPAL": "{{riak.auth-principal}}"{{/riak.auth-principal}}
+        {{#riak.auth-provider}},"RIAK_MESOS_PROVIDER": "{{riak.auth-provider}}"{{/riak.auth-provider}}
+        {{#riak.auth-secret-file}},"RIAK_MESOS_SECRET_FILE": "{{riak.auth-secret-file}}"{{/riak.auth-secret-file}}
+        {{#riak.role}},"RIAK_MESOS_ROLE": "{{riak.role}}"{{/riak.role}}
+        {{#riak.ip}},"RIAK_MESOS_IP": "{{riak.ip}}"{{/riak.ip}}
+        {{#riak.hostname}},"RIAK_MESOS_HOSTNAME": "{{riak.hostname}}"{{/riak.hostname}}
+        {{#riak.failover-timeout}},"RIAK_MESOS_FAILOVER_TIMEOUT": "{{riak.failover-timeout}}"{{/riak.failover-timeout}}
+        {{#riak.node.cpus}},"RIAK_MESOS_NODE_CPUS": "{{riak.node.cpus}}"{{/riak.node.cpus}}
+        {{#riak.node.mem}},"RIAK_MESOS_NODE_MEM": "{{riak.node.mem}}"{{/riak.node.mem}}
+        {{#riak.node.disk}},"RIAK_MESOS_NODE_DISK": "{{riak.node.disk}}"{{/riak.node.disk}}
+        {{#riak.executor.cpus}},"RIAK_MESOS_EXECUTOR_CPUS": "{{riak.executor.cpus}}"{{/riak.executor.cpus}}
+        {{#riak.executor.mem}},"RIAK_MESOS_EXECUTOR_MEM": "{{riak.executor.mem}}"{{/riak.executor.mem}}
+    },
+    "healthChecks": [
+    {
+      "path": "/healthcheck",
+      "portIndex": 0,
+      "protocol": "HTTP",
+      "gracePeriodSeconds": {{riak.healthcheck-grace-period-seconds}},
+      "intervalSeconds": {{riak.healthcheck-interval-seconds}},
+      "timeoutSeconds": {{riak.healthcheck-timeout-seconds}},
+      "maxConsecutiveFailures": {{riak.healthcheck-max-consecutive-failures}},
+      "ignoreHttp1xx": false
+    }],
+    "labels": {
+        "DCOS_PACKAGE_FRAMEWORK_NAME": "{{riak.framework-name}}"
+    }
+}

--- a/repo/packages/R/riak/2/package.json
+++ b/repo/packages/R/riak/2/package.json
@@ -1,0 +1,20 @@
+{
+  "packagingVersion": "2.0",
+  "name": "riak",
+  "version": "1.3.0",
+  "framework": true,
+  "tags": ["mesosphere", "framework", "database", "riak"],
+  "maintainer": "help@basho.com",
+  "description": "A distributed NoSQL key-value data store that offers high availability, fault tolerance, operational simplicity, and scalability.",
+  "scm": "https://github.com/basho-labs/riak-mesos.git",
+  "website": "http://basho-labs.github.io/riak-mesos/",
+  "postInstallNotes": "Thank you for installing Riak on Mesos. Visit https://github.com/basho-labs/riak-mesos for usage information.",
+  "preInstallNotes": "The Riak framework should have at least 1GB of RAM and 0.5 CPUs to perform successfully.",
+  "postUninstallNotes": "The Mesos Riak Framework has been uninstalled and will no longer run. In order to fully remove Riak from the DCOS cluster, delete the /riak/frameworks/<framework-id> or /riak nodes from Zookeeper.",
+  "licenses": [
+    {
+      "name": "Apache License Version 2.0",
+      "url": "https://github.com/basho-labs/riak-mesos/blob/master/LICENSE"
+    }
+  ]
+}

--- a/repo/packages/R/riak/2/resource.json
+++ b/repo/packages/R/riak/2/resource.json
@@ -1,0 +1,10 @@
+{
+  "images": {
+    "icon-small": "http://riak-tools.s3.amazonaws.com/riak-mesos/riak-mesos-small.png",
+    "icon-medium": "http://riak-tools.s3.amazonaws.com/riak-mesos/riak-mesos-medium.png",
+    "icon-large": "http://riak-tools.s3.amazonaws.com/riak-mesos/riak-mesos-large.png",
+    "screenshots": [
+      "http://riak-tools.s3.amazonaws.com/riak-mesos/riak-mesos-screenshot.png"
+    ]
+  }
+}


### PR DESCRIPTION
This adds v1.3.0 of RMF using the old, combined `riak` package.

Unless there's a real demand for it, this will be the last set of updates for this branch.

Please consider upgrading to the `develop` branch, where you'll find split packages for `riak-kv` and `riak-ts`.