### PR TITLE
Use tools@1.3.3 to pin dcos req at 0.4.11

### DIFF
--- a/repo/packages/R/riak/2/command.json
+++ b/repo/packages/R/riak/2/command.json
@@ -1,6 +1,6 @@
 {
   "pip": [
-    "git+https://github.com/basho-labs/riak-mesos-tools.git@1.3.2#egg=riak_mesos",
+    "git+https://github.com/basho-labs/riak-mesos-tools.git@1.3.3#egg=riak_mesos",
     "git+https://github.com/basho-labs/riak-mesos-dcos-shims@master"
   ]
 }


### PR DESCRIPTION
Related to https://github.com/basho-labs/riak-mesos-tools/issues/54